### PR TITLE
v7.1.0 — Generic OIDC alongside Microsoft Entra ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to WulfVault will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.0] - Aurora - 2026-05-30
+
+Generic OpenID Connect support alongside Microsoft Entra ID. WulfVault is
+no longer tied to Microsoft for SSO — works with Google Workspace, Okta,
+Keycloak, Authelia, Auth0 or any OIDC-compliant issuer.
+
+### Added
+
+- **Generic OpenID Connect provider** — second option in the *Identity
+  Providers* admin page. Configure with issuer URL + client ID/secret;
+  no multi-tenant quirks, strict issuer matching.
+- **Provider type dropdown** with two options:
+  - *Microsoft Entra ID (Azure AD)* — special-cased multi-tenant aliases
+    (`common`/`organizations`/`consumers`) + `tid`-claim validation.
+  - *Generic OpenID Connect* — any OIDC-compliant provider.
+- **Configurable provider display name** — login button and invite email
+  subject/body use it ("Sign in with Microsoft", "Sign in with Google",
+  "Sign in with SSO"). Defaults: "Microsoft" for Entra, "SSO" for Generic.
+- **New canonical routes** `/auth/oidc/{login,callback}`. The legacy
+  `/auth/entra/{login,callback}` routes still work — existing Entra app
+  registrations don't need to update their redirect URI.
+- **Provider-aware login button** — Microsoft 4-tile logo for Entra,
+  neutral lock icon for Generic OIDC.
+- **Inline issuer help** in the admin UI listing common provider issuer
+  URLs (Google, Okta, Keycloak, Authelia, Auth0).
+
+### Changed
+
+- Version bumped from `7.0.0` to `7.1.0`.
+- `EntraConfig` is now a type alias for `IdentityProviderConfig` — existing
+  callers compile unchanged. `LoadEntraConfig` / `SaveEntraConfig` kept as
+  back-compat shims.
+- SSO cookie path widened from `/auth/entra/` to `/auth/` so cookies
+  survive either route prefix.
+
+### Backwards compatibility
+
+- Installs that pre-date v7.1 default to `ProviderType=entra` on first
+  load — no migration needed, upgrade is silent.
+- New configuration keys (`entra_provider_type`,
+  `entra_provider_display_name`, `entra_generic_issuer_url`,
+  `entra_generic_scopes`) are written alongside existing keys. Old
+  binaries ignore them.
+- Database schema: no changes.
+
+### Upgrade
+
+Drop in `wulfvault-linux-amd64` from the release, restart. Rollback to
+v7.0 is binary-swap only.
+
 ## [7.0.0] - Aurora - 2026-05-30
 
 Codename shift: leaving BloodMoon (werewolf motif) behind. **Aurora** = the

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # WulfVault - Enterprise File Sharing Platform
 
-**Version 7.0.0 Aurora** | **Self-Hosted** | **Open Source** | **AGPL-3.0**
+**Version 7.1.0 Aurora** | **Self-Hosted** | **Open Source** | **AGPL-3.0**
 
-> **What's new in 7.0 Aurora:** Microsoft Entra ID SSO **plus** an admin-driven invite flow. Create an account, click invite, the user receives an email with a sign-in link and activates by signing in with their Microsoft work/school account — no password handoff required. See [§ Microsoft Entra ID SSO (Aurora)](#-microsoft-entra-id-sso-aurora) below.
+> **What's new in 7.1 Aurora:** **Generic OpenID Connect** alongside Microsoft Entra ID. Sign-in works with Google Workspace, Okta, Keycloak, Authelia, Auth0 or any OIDC-compliant issuer — pick the provider type in *Identity Providers* and fill in an issuer URL + client ID/secret. Carries over the v7.0 admin invite flow. See [§ Single Sign-On (Aurora)](#-single-sign-on-aurora) below.
 
-WulfVault is a professional-grade, self-hosted file sharing platform designed for organizations that demand security, accountability, and complete control over their data. Built with Go for exceptional performance and reliability, WulfVault provides a complete alternative to commercial file transfer services, eliminating subscription costs while offering superior features: multi-user management with role-based access, per-user storage quotas, enterprise-grade audit logging for compliance (GDPR, SOC 2, HIPAA), comprehensive download tracking, branded download pages, two-factor authentication, **Microsoft Entra ID SSO with invite-based provisioning**, self-service password management, file request portals, and GDPR-compliant account deletion.
+WulfVault is a professional-grade, self-hosted file sharing platform designed for organizations that demand security, accountability, and complete control over their data. Built with Go for exceptional performance and reliability, WulfVault provides a complete alternative to commercial file transfer services, eliminating subscription costs while offering superior features: multi-user management with role-based access, per-user storage quotas, enterprise-grade audit logging for compliance (GDPR, SOC 2, HIPAA), comprehensive download tracking, branded download pages, two-factor authentication, **Microsoft Entra ID + Generic OpenID Connect SSO with invite-based provisioning**, self-service password management, file request portals, and GDPR-compliant account deletion.
 
 **Perfect for:** Law enforcement agencies, healthcare providers, legal firms, creative agencies, government departments, educational institutions, and any organization handling sensitive or large files that require detailed download tracking, compliance documentation, and enterprise-grade security.
 
@@ -171,19 +171,24 @@ WulfVault solves this by providing:
   - Detailed metrics for system administrators
   - Accessible via Server → SysMonitor Logs
 
-### 🔑 Microsoft Entra ID SSO (Aurora)
-- **OpenID Connect Authorization Code + PKCE** flow against Microsoft Entra ID (Azure AD).
+### 🔑 Single Sign-On (Aurora)
+- **Two provider types** selectable in *Server → Identity Providers*:
+  - **Microsoft Entra ID (Azure AD)** — special-cased with multi-tenant aliases (`common` / `organizations` / `consumers`) and explicit `tid`-claim validation.
+  - **Generic OpenID Connect** (v7.1) — works with any OIDC-compliant issuer: Google Workspace, Okta, Keycloak, Authelia, Auth0, or your own IdP. Inline help in the admin UI lists the issuer URL pattern for each common provider.
+- **OpenID Connect Authorization Code + PKCE** flow under the hood (`coreos/go-oidc/v3`).
 - **Additive to local accounts** — break-glass and service accounts (e.g. Evidence Courier) keep using password sign-in. Each user is either `local` or `entra`; no silent binding.
-- **Admin invite flow (new in 7.0):**
+- **Admin invite flow (v7.0):**
   - On `/admin/users/create`, choose **Account type: Entra ID (invite)**.
-  - System creates a user row pre-bound to Entra (`IdentityProvider="entra"`, empty `ExternalID`) and sends an email with a sign-in link.
+  - System creates a user row pre-bound to SSO (`IdentityProvider="entra"`, empty `ExternalID`) and sends an email with a sign-in link.
   - User clicks link → lands on `/login?invite=<email>` with the email field pre-filled and a "You've been invited" banner shown.
-  - User clicks **Sign in with Microsoft** → completes Entra OIDC → returns and is automatically bound to the pre-created account (no manual admin step).
+  - User clicks **Sign in with {Provider}** → completes OIDC → returns and is automatically bound to the pre-created account (no manual admin step).
+- **Configurable provider display name** — the login button and invite emails say "Sign in with Microsoft" / "Sign in with Google" / "Sign in with SSO" — whatever you configure.
 - **Resend invite** — admin can re-send the invitation at any time from the user list (shows "Invite pending" until first sign-in).
 - **Auto-provisioning** (optional, per setting) for any sign-in within an allow-listed email domain.
 - **Admin escape hatch** `entra_force_local_only` hides the SSO button AND 404s the callback even when SSO is otherwise configured.
-- **Configuration:** Server → Identity Providers in the admin UI. Client secret encrypted at rest with AES-256-GCM. Multi-tenant aliases (`common`/`organizations`/`consumers`) supported with explicit `tid`-claim validation.
-- **Tag:** `v7.0.0-aurora-beta1` — production-grade code; the customer-facing OIDC round-trip is verified live; awaiting first real-user sign-in to mark stable.
+- **Routes:** `/auth/oidc/{login,callback}` (v7.1 canonical). The legacy `/auth/entra/{login,callback}` paths still work, so existing Entra app registrations don't need their redirect URI updated.
+- **Configuration:** Client secret encrypted at rest with AES-256-GCM. One provider configured at a time per install.
+- **Tag:** `v7.1.0` — production-deployed; the customer-facing OIDC round-trip is verified live for Entra. First real-customer Generic OIDC sign-in is the next milestone.
 
 ### 🔐 Security & Authentication
 - **Two-Factor Authentication (2FA):**

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	Version = "7.0.0 Aurora"
+	Version = "7.1.0 Aurora"
 )
 
 var (

--- a/internal/auth/entra.go
+++ b/internal/auth/entra.go
@@ -74,17 +74,35 @@ func (c *EntraClaims) ExternalIdentifier() string {
 	return strings.TrimSpace(c.Subject)
 }
 
-// BuildEntraProvider constructs an EntraProvider from the current configuration.
-// Returns Enabled=false if SSO is disabled, force-local is set, or required fields
-// are missing — caller can short-circuit to a 404 without leaking config state.
+// BuildEntraProvider constructs an SSO provider from the current configuration.
+// Despite the name (kept for git continuity), this function handles both
+// Entra ID and Generic OIDC providers based on cfg.EffectiveProviderType().
 //
-// ctx should be a request-scoped context; OIDC discovery is performed synchronously.
+// Returns Enabled=false if SSO is disabled, force-local is set, or required
+// fields are missing — caller can short-circuit to a 404 without leaking
+// config state.
+//
+// ctx should be a request-scoped context; OIDC discovery is performed
+// synchronously.
 func BuildEntraProvider(ctx context.Context, cfg *EntraConfig) (*EntraProvider, error) {
 	if cfg == nil || !cfg.ShouldShowSSOButton() {
 		return &EntraProvider{Enabled: false}, nil
 	}
-	if cfg.TenantID == "" || cfg.ClientID == "" || cfg.ClientSecret == "" {
-		return &EntraProvider{Enabled: false}, errors.New("entra: tenant_id, client_id and client_secret all required")
+	if cfg.ClientID == "" || cfg.ClientSecret == "" {
+		return &EntraProvider{Enabled: false}, errors.New("oidc: client_id and client_secret are required")
+	}
+
+	if cfg.IsGenericOIDC() {
+		return buildGenericOIDCProvider(ctx, cfg)
+	}
+	return buildEntraOIDCProvider(ctx, cfg)
+}
+
+// buildEntraOIDCProvider handles Microsoft-specific multi-tenant aliases
+// (common / organizations / consumers) and tid-claim validation.
+func buildEntraOIDCProvider(ctx context.Context, cfg *EntraConfig) (*EntraProvider, error) {
+	if cfg.TenantID == "" {
+		return &EntraProvider{Enabled: false}, errors.New("entra: tenant_id is required")
 	}
 
 	issuer := "https://login.microsoftonline.com/" + cfg.TenantID + "/v2.0"
@@ -102,17 +120,12 @@ func BuildEntraProvider(ctx context.Context, cfg *EntraConfig) (*EntraProvider, 
 		discoveryCtx = oidc.InsecureIssuerURLContext(ctx, issuer)
 	}
 
-	// Discovery: fetches /.well-known/openid-configuration and JWKS.
-	// go-oidc caches keys internally with auto-refresh on signature failures.
 	provider, err := oidc.NewProvider(discoveryCtx, issuer)
 	if err != nil {
 		return &EntraProvider{Enabled: false}, fmt.Errorf("entra: oidc discovery failed for tenant %s: %w", cfg.TenantID, err)
 	}
 
 	verifierCfg := &oidc.Config{ClientID: cfg.ClientID}
-	// For multi-tenant aliases the per-token issuer differs from the
-	// discovery issuer — skip the library check and rely on our explicit
-	// `tid` validation downstream.
 	if t == "common" || t == "organizations" || t == "consumers" {
 		verifierCfg.SkipIssuerCheck = true
 	}
@@ -123,10 +136,40 @@ func BuildEntraProvider(ctx context.Context, cfg *EntraConfig) (*EntraProvider, 
 		ClientSecret: cfg.ClientSecret,
 		Endpoint:     provider.Endpoint(),
 		RedirectURL:  cfg.RedirectURI,
-		// openid + profile + email is the minimum for identity resolution.
-		// Add "offline_access" if/when we want refresh tokens; we don't yet
-		// because Entra is consulted only at login, not on every request.
-		Scopes: []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+	}
+
+	return &EntraProvider{
+		Enabled:  true,
+		Config:   cfg,
+		OAuth2:   oauth2Cfg,
+		Verifier: verifier,
+		Provider: provider,
+	}, nil
+}
+
+// buildGenericOIDCProvider handles any OIDC-compliant provider (Google,
+// Okta, Keycloak, Authelia, etc). Uses cfg.IssuerURL directly with strict
+// issuer matching — no multi-tenant quirks.
+func buildGenericOIDCProvider(ctx context.Context, cfg *EntraConfig) (*EntraProvider, error) {
+	issuer := strings.TrimRight(strings.TrimSpace(cfg.IssuerURL), "/")
+	if issuer == "" {
+		return &EntraProvider{Enabled: false}, errors.New("oidc: issuer_url is required for generic OIDC")
+	}
+
+	provider, err := oidc.NewProvider(ctx, issuer)
+	if err != nil {
+		return &EntraProvider{Enabled: false}, fmt.Errorf("oidc: discovery failed for issuer %s: %w", issuer, err)
+	}
+
+	verifier := provider.Verifier(&oidc.Config{ClientID: cfg.ClientID})
+
+	oauth2Cfg := &oauth2.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		Endpoint:     provider.Endpoint(),
+		RedirectURL:  cfg.RedirectURI,
+		Scopes:       cfg.EffectiveScopes(),
 	}
 
 	return &EntraProvider{
@@ -217,10 +260,11 @@ func (p *EntraProvider) ExchangeCode(ctx context.Context, code, codeVerifier str
 		return nil, fmt.Errorf("entra: failed to parse id_token claims: %w", err)
 	}
 
-	// Defense-in-depth: verify the token's tenant matches the configured tenant.
-	// Microsoft already does this via the issuer check inside Verifier, but
-	// belt-and-braces protects against a future config/provider mix-up.
-	if p.Config.TenantID != "" && claims.TenantID != "" && claims.TenantID != p.Config.TenantID {
+	// Defense-in-depth tenant validation — only meaningful for Entra. Generic
+	// OIDC providers have no `tid` claim. For Entra: belt-and-braces against
+	// a future config/provider mix-up; Microsoft already enforces this via
+	// the issuer check inside Verifier.
+	if p.Config.IsEntra() && p.Config.TenantID != "" && claims.TenantID != "" && claims.TenantID != p.Config.TenantID {
 		return nil, fmt.Errorf("entra: tenant mismatch: got %s, expected %s", claims.TenantID, p.Config.TenantID)
 	}
 

--- a/internal/auth/entra_config.go
+++ b/internal/auth/entra_config.go
@@ -3,9 +3,10 @@
 // Licensed under the GNU Affero General Public License v3.0 (AGPL-3.0)
 // You must retain this notice in any copy or derivative work.
 
-// entra_config.go — read/write Microsoft Entra ID SSO settings stored in the
-// Configuration table. The OIDC flow itself is added in a follow-up PR; this
-// file only handles persisted configuration.
+// entra_config.go — identity-provider configuration (Entra ID + Generic OIDC).
+// File kept under the entra_*.go name for git history continuity; the type
+// is provider-agnostic now (IdentityProviderConfig). EntraConfig remains as
+// a type alias so existing callers don't need to change.
 
 package auth
 
@@ -19,46 +20,133 @@ import (
 	"github.com/Frimurare/WulfVault/internal/secrets"
 )
 
-// Configuration keys used by Entra ID SSO.
+// Provider type values stored in cfgProviderType.
 const (
-	cfgEntraEnabled         = "entra_enabled"
-	cfgEntraForceLocalOnly  = "entra_force_local_only"
-	cfgEntraTenantID        = "entra_tenant_id"
-	cfgEntraClientID        = "entra_client_id"
-	cfgEntraClientSecretEnc = "entra_client_secret_enc"
-	cfgEntraRedirectURI     = "entra_redirect_uri"
-	cfgEntraAutoProvision   = "entra_auto_provision"
-	cfgEntraDefaultRole     = "entra_default_role"
-	cfgEntraAllowedDomains  = "entra_allowed_domains"
+	ProviderTypeEntra       = "entra"
+	ProviderTypeGenericOIDC = "generic_oidc"
 )
 
-// EntraConfig is the admin-facing settings struct. ClientSecret is plaintext
-// in this struct (encrypted only at rest in the Configuration table).
-type EntraConfig struct {
-	Enabled         bool
-	ForceLocalOnly  bool
-	TenantID        string
-	ClientID        string
-	ClientSecret    string
-	RedirectURI     string
-	AutoProvision   bool
-	DefaultRole     models.UserRank
-	AllowedDomains  []string // lower-cased email domains; empty = any
+// Configuration keys. Kept with "entra_" prefix for v6/v7.0 install
+// continuity — DBs already have these rows, renaming would require a
+// migration with no behavioural benefit.
+const (
+	cfgEntraEnabled            = "entra_enabled"
+	cfgEntraForceLocalOnly     = "entra_force_local_only"
+	cfgEntraTenantID           = "entra_tenant_id"
+	cfgEntraClientID           = "entra_client_id"
+	cfgEntraClientSecretEnc    = "entra_client_secret_enc"
+	cfgEntraRedirectURI        = "entra_redirect_uri"
+	cfgEntraAutoProvision      = "entra_auto_provision"
+	cfgEntraDefaultRole        = "entra_default_role"
+	cfgEntraAllowedDomains     = "entra_allowed_domains"
+	// Added in v7.1.0 for multi-provider support
+	cfgProviderType            = "entra_provider_type"          // "entra" | "generic_oidc"
+	cfgProviderDisplayName     = "entra_provider_display_name"  // "Microsoft", "Google", custom
+	cfgGenericIssuerURL        = "entra_generic_issuer_url"     // for Generic OIDC
+	cfgGenericScopes           = "entra_generic_scopes"         // space-sep, default "openid email profile"
+)
+
+// IdentityProviderConfig holds the configured single sign-on provider.
+// One provider per install in v7.1 (Entra OR Generic OIDC, not both).
+//
+// ClientSecret is plaintext in this struct; it is encrypted at rest in
+// the Configuration table.
+type IdentityProviderConfig struct {
+	Enabled        bool
+	ForceLocalOnly bool
+
+	// ProviderType selects which provider-specific code path runs.
+	// "entra"        → Microsoft Entra ID (uses TenantID, multi-tenant aliases)
+	// "generic_oidc" → Any OIDC-compliant provider (uses IssuerURL)
+	ProviderType string
+
+	// ProviderDisplayName is shown to end-users (login button, invite email).
+	// Defaults to "Microsoft" for entra, "SSO" for generic_oidc.
+	ProviderDisplayName string
+
+	// Shared OAuth/OIDC fields
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+
+	// Entra-specific (used when ProviderType == "entra")
+	// May be a tenant GUID or one of "common", "organizations", "consumers".
+	TenantID string
+
+	// Generic-OIDC-specific (used when ProviderType == "generic_oidc")
+	// IssuerURL is the OIDC issuer (e.g. "https://accounts.google.com",
+	// "https://your-tenant.okta.com", "https://your-keycloak/realms/your-realm").
+	IssuerURL string
+
+	// Scopes for Generic OIDC. Space-separated. Defaults to "openid email profile".
+	// Entra always uses the same baseline scopes — this field is ignored for it.
+	Scopes string
+
+	// Provisioning rules (shared across providers)
+	AutoProvision  bool
+	DefaultRole    models.UserRank
+	AllowedDomains []string // lower-cased email domains; empty = any
 }
 
+// EntraConfig is a back-compatibility type alias. Existing callers that
+// type-assert *EntraConfig keep working unchanged — under the hood it's
+// always an IdentityProviderConfig now.
+type EntraConfig = IdentityProviderConfig
+
 // ShouldShowSSOButton reports whether the login page should expose the
-// "Sign in with Microsoft" button. ForceLocalOnly overrides Enabled.
-func (c *EntraConfig) ShouldShowSSOButton() bool {
+// "Sign in with X" button. ForceLocalOnly overrides Enabled.
+func (c *IdentityProviderConfig) ShouldShowSSOButton() bool {
 	return c.Enabled && !c.ForceLocalOnly
 }
 
-// LoadEntraConfig reads the Entra settings from the Configuration table.
-// Missing keys produce zero-values. Returns an error only on DB or decryption
-// failures.
-func LoadEntraConfig(db *database.Database) (*EntraConfig, error) {
-	cfg := &EntraConfig{
-		AutoProvision: true,                  // sensible default — admin can disable
-		DefaultRole:   models.UserLevelUser,  // least-privileged by default
+// EffectiveProviderType returns ProviderType with the default ("entra")
+// substituted for empty string. This lets installs that pre-date v7.1
+// continue to behave as Entra without an explicit migration.
+func (c *IdentityProviderConfig) EffectiveProviderType() string {
+	if c.ProviderType == "" {
+		return ProviderTypeEntra
+	}
+	return c.ProviderType
+}
+
+// IsEntra is a convenience for "should I run the Entra-specific code path".
+func (c *IdentityProviderConfig) IsEntra() bool {
+	return c.EffectiveProviderType() == ProviderTypeEntra
+}
+
+// IsGenericOIDC is a convenience for "should I run the generic OIDC code path".
+func (c *IdentityProviderConfig) IsGenericOIDC() bool {
+	return c.EffectiveProviderType() == ProviderTypeGenericOIDC
+}
+
+// EffectiveDisplayName returns the configured ProviderDisplayName or a
+// sensible default based on the provider type.
+func (c *IdentityProviderConfig) EffectiveDisplayName() string {
+	if c.ProviderDisplayName != "" {
+		return c.ProviderDisplayName
+	}
+	if c.IsEntra() {
+		return "Microsoft"
+	}
+	return "SSO"
+}
+
+// EffectiveScopes returns the configured scopes or the OIDC baseline.
+func (c *IdentityProviderConfig) EffectiveScopes() []string {
+	s := strings.TrimSpace(c.Scopes)
+	if s == "" {
+		return []string{"openid", "email", "profile"}
+	}
+	return strings.Fields(s)
+}
+
+// LoadIdentityProviderConfig reads SSO settings from the Configuration table.
+// Missing keys produce zero-values with sensible defaults. Returns an error
+// only on DB or decryption failures.
+func LoadIdentityProviderConfig(db *database.Database) (*IdentityProviderConfig, error) {
+	cfg := &IdentityProviderConfig{
+		AutoProvision: true,
+		DefaultRole:   models.UserLevelUser,
 	}
 
 	getBool := func(key string, dst *bool) error {
@@ -67,7 +155,7 @@ func LoadEntraConfig(db *database.Database) (*EntraConfig, error) {
 			return fmt.Errorf("read %s: %w", key, err)
 		}
 		if v == "" {
-			return nil // keep default
+			return nil
 		}
 		*dst = v == "1" || strings.EqualFold(v, "true")
 		return nil
@@ -88,6 +176,12 @@ func LoadEntraConfig(db *database.Database) (*EntraConfig, error) {
 	if err := getBool(cfgEntraForceLocalOnly, &cfg.ForceLocalOnly); err != nil {
 		return nil, err
 	}
+	if err := getStr(cfgProviderType, &cfg.ProviderType); err != nil {
+		return nil, err
+	}
+	if err := getStr(cfgProviderDisplayName, &cfg.ProviderDisplayName); err != nil {
+		return nil, err
+	}
 	if err := getStr(cfgEntraTenantID, &cfg.TenantID); err != nil {
 		return nil, err
 	}
@@ -97,18 +191,22 @@ func LoadEntraConfig(db *database.Database) (*EntraConfig, error) {
 	if err := getStr(cfgEntraRedirectURI, &cfg.RedirectURI); err != nil {
 		return nil, err
 	}
+	if err := getStr(cfgGenericIssuerURL, &cfg.IssuerURL); err != nil {
+		return nil, err
+	}
+	if err := getStr(cfgGenericScopes, &cfg.Scopes); err != nil {
+		return nil, err
+	}
 	if err := getBool(cfgEntraAutoProvision, &cfg.AutoProvision); err != nil {
 		return nil, err
 	}
 
-	// Default role: stored as the numeric UserRank.
 	if v, err := db.GetConfigValue(cfgEntraDefaultRole); err == nil && v != "" {
 		if n, perr := strconv.Atoi(v); perr == nil {
 			cfg.DefaultRole = models.UserRank(n)
 		}
 	}
 
-	// Allowed domains: comma-separated, lower-cased on the way in.
 	if v, err := db.GetConfigValue(cfgEntraAllowedDomains); err == nil && v != "" {
 		for _, d := range strings.Split(v, ",") {
 			d = strings.ToLower(strings.TrimSpace(d))
@@ -118,7 +216,6 @@ func LoadEntraConfig(db *database.Database) (*EntraConfig, error) {
 		}
 	}
 
-	// Decrypt the client secret if present.
 	if enc, err := db.GetConfigValue(cfgEntraClientSecretEnc); err == nil && enc != "" {
 		key, kerr := secrets.GetOrCreateMasterKey(db)
 		if kerr != nil {
@@ -134,10 +231,16 @@ func LoadEntraConfig(db *database.Database) (*EntraConfig, error) {
 	return cfg, nil
 }
 
-// SaveEntraConfig persists the Entra settings. ClientSecret is encrypted with
-// the install's master key before writing. An empty ClientSecret preserves the
-// existing one (so editing the page without re-entering the secret is safe).
-func SaveEntraConfig(db *database.Database, cfg *EntraConfig) error {
+// LoadEntraConfig is the back-compatibility alias. Identical to
+// LoadIdentityProviderConfig — kept so existing callers don't need to change.
+func LoadEntraConfig(db *database.Database) (*EntraConfig, error) {
+	return LoadIdentityProviderConfig(db)
+}
+
+// SaveIdentityProviderConfig persists SSO settings. ClientSecret is encrypted
+// before writing. An empty ClientSecret preserves the existing one (so editing
+// the page without re-entering the secret is safe).
+func SaveIdentityProviderConfig(db *database.Database, cfg *IdentityProviderConfig) error {
 	boolStr := func(b bool) string {
 		if b {
 			return "1"
@@ -151,6 +254,17 @@ func SaveEntraConfig(db *database.Database, cfg *EntraConfig) error {
 	if err := db.SetConfigValue(cfgEntraForceLocalOnly, boolStr(cfg.ForceLocalOnly)); err != nil {
 		return err
 	}
+	// Normalize provider type — anything other than "generic_oidc" → "entra".
+	pt := strings.TrimSpace(cfg.ProviderType)
+	if pt != ProviderTypeGenericOIDC {
+		pt = ProviderTypeEntra
+	}
+	if err := db.SetConfigValue(cfgProviderType, pt); err != nil {
+		return err
+	}
+	if err := db.SetConfigValue(cfgProviderDisplayName, strings.TrimSpace(cfg.ProviderDisplayName)); err != nil {
+		return err
+	}
 	if err := db.SetConfigValue(cfgEntraTenantID, strings.TrimSpace(cfg.TenantID)); err != nil {
 		return err
 	}
@@ -160,6 +274,12 @@ func SaveEntraConfig(db *database.Database, cfg *EntraConfig) error {
 	if err := db.SetConfigValue(cfgEntraRedirectURI, strings.TrimSpace(cfg.RedirectURI)); err != nil {
 		return err
 	}
+	if err := db.SetConfigValue(cfgGenericIssuerURL, strings.TrimSpace(cfg.IssuerURL)); err != nil {
+		return err
+	}
+	if err := db.SetConfigValue(cfgGenericScopes, strings.TrimSpace(cfg.Scopes)); err != nil {
+		return err
+	}
 	if err := db.SetConfigValue(cfgEntraAutoProvision, boolStr(cfg.AutoProvision)); err != nil {
 		return err
 	}
@@ -167,7 +287,6 @@ func SaveEntraConfig(db *database.Database, cfg *EntraConfig) error {
 		return err
 	}
 
-	// Normalize allowed domains: lower-case, deduplicate.
 	seen := map[string]bool{}
 	cleaned := make([]string, 0, len(cfg.AllowedDomains))
 	for _, d := range cfg.AllowedDomains {
@@ -182,7 +301,6 @@ func SaveEntraConfig(db *database.Database, cfg *EntraConfig) error {
 		return err
 	}
 
-	// Empty incoming secret = keep existing (admin didn't retype it).
 	if strings.TrimSpace(cfg.ClientSecret) != "" {
 		key, err := secrets.GetOrCreateMasterKey(db)
 		if err != nil {
@@ -198,4 +316,9 @@ func SaveEntraConfig(db *database.Database, cfg *EntraConfig) error {
 	}
 
 	return nil
+}
+
+// SaveEntraConfig is the back-compatibility alias.
+func SaveEntraConfig(db *database.Database, cfg *EntraConfig) error {
+	return SaveIdentityProviderConfig(db, cfg)
 }

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -8,6 +8,7 @@ package email
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Frimurare/WulfVault/internal/database"
@@ -551,10 +552,16 @@ Do not reply to this email.`, companyName, adminName, adminEmail, companyName, e
 }
 
 // SendEntraInviteEmail sends an invitation to a user whose account was created
-// with IdentityProvider="entra". They click the link, land on /login with email
-// pre-filled, sign in with Microsoft, and ResolveOrProvisionUser binds the
-// freshly issued ExternalID to the pre-created row.
-func SendEntraInviteEmail(email, name, serverURL, companyName, adminName, adminEmail string) error {
+// with IdentityProvider="entra" / "oidc". They click the link, land on /login
+// with email pre-filled, sign in with the configured SSO provider (Microsoft,
+// Google, Okta, etc), and ResolveOrProvisionUser binds the freshly issued
+// ExternalID to the pre-created row.
+//
+// providerDisplayName: human-readable provider name shown in subject and body
+// ("Microsoft", "Google", "SSO" — whatever the admin configured). Pass "" to
+// fall back to the generic "your SSO provider" wording. (Function name kept
+// for v7.0 caller compatibility; it is provider-agnostic since v7.1.)
+func SendEntraInviteEmail(email, name, providerDisplayName, serverURL, companyName, adminName, adminEmail string) error {
 	loginLink := fmt.Sprintf("%s/login?invite=%s", serverURL, url.QueryEscape(email))
 
 	displayName := name
@@ -562,7 +569,18 @@ func SendEntraInviteEmail(email, name, serverURL, companyName, adminName, adminE
 		displayName = email
 	}
 
-	subject := fmt.Sprintf("You're invited to %s — sign in with Microsoft", companyName)
+	providerName := strings.TrimSpace(providerDisplayName)
+	if providerName == "" {
+		providerName = "your SSO provider"
+	}
+	// The 4-tile logo is Microsoft-specific. For non-Entra providers we omit it.
+	isEntra := strings.EqualFold(providerName, "Microsoft")
+	logoSpan := ""
+	if isEntra {
+		logoSpan = `<span class="ms-logo"></span>`
+	}
+
+	subject := fmt.Sprintf("You're invited to %s — sign in with %s", companyName, providerName)
 
 	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en">
@@ -590,19 +608,19 @@ func SendEntraInviteEmail(email, name, serverURL, companyName, adminName, adminE
 	<div class="container">
 		<div class="header">
 			<h1>You're invited to %s</h1>
-			<p>Sign in with your Microsoft account to get started</p>
+			<p>Sign in with your %s account to get started</p>
 		</div>
 		<div class="content">
 			<div class="invite-box">
 				<h2>Hi %s,</h2>
 				<p><strong>%s</strong> (%s) has created an account for you on <strong>%s</strong>.</p>
-				<p>This account uses <strong>Microsoft Entra ID</strong> (single sign-on) — you'll use your existing Microsoft work or school account to sign in. No new password to remember.</p>
+				<p>This account uses <strong>%s single sign-on</strong> — you'll use your existing %s credentials to sign in. No new password to remember.</p>
 			</div>
 
 			<div class="action-box">
 				<h2 style="color: #004155; margin-bottom: 15px;">Activate your account</h2>
-				<p style="margin-bottom: 25px;">Click below to sign in. You'll be redirected to Microsoft to authenticate, then back here.</p>
-				<a href="%s" class="button"><span class="ms-logo"></span>Sign in with Microsoft</a>
+				<p style="margin-bottom: 25px;">Click below to sign in. You'll be redirected to %s to authenticate, then back here.</p>
+				<a href="%s" class="button">%sSign in with %s</a>
 				<p style="font-size: 13px; color: #999; margin-top: 20px;">First sign-in activates your account automatically.</p>
 			</div>
 
@@ -620,7 +638,11 @@ func SendEntraInviteEmail(email, name, serverURL, companyName, adminName, adminE
 		</div>
 	</div>
 </body>
-</html>`, companyName, displayName, adminName, adminEmail, companyName, loginLink, email, loginLink, companyName)
+</html>`,
+		companyName, providerName,
+		displayName, adminName, adminEmail, companyName, providerName, providerName,
+		providerName, loginLink, logoSpan, providerName,
+		email, loginLink, companyName)
 
 	textBody := fmt.Sprintf(`You're invited to %s
 
@@ -628,18 +650,18 @@ Hi %s,
 
 %s (%s) has created an account for you on %s.
 
-This account uses Microsoft Entra ID (single sign-on). You'll use your existing Microsoft work or school account — no new password to remember.
+This account uses %s single sign-on. You'll use your existing %s credentials — no new password to remember.
 
 Your login email: %s
 
-Activate your account by clicking this link and signing in with Microsoft:
+Activate your account by clicking this link and signing in with %s:
 %s
 
 First sign-in activates your account automatically.
 
 ---
 This is an automated message from %s.
-Do not reply to this email.`, companyName, displayName, adminName, adminEmail, companyName, email, loginLink, companyName)
+Do not reply to this email.`, companyName, displayName, adminName, adminEmail, companyName, providerName, providerName, email, providerName, loginLink, companyName)
 
 	provider, err := GetActiveProvider(database.DB)
 	if err != nil {

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -528,13 +528,19 @@ func (s *Server) createEntraInvitedUser(w http.ResponseWriter, r *http.Request, 
 
 // sendEntraInviteMail centralises the URL-correction + admin-context lookup
 // so both create-and-invite and resend-invite share the exact same send path.
+// v7.1: resolves the configured provider display name so the email mentions
+// the right brand (Microsoft / Google / Okta / etc).
 func sendEntraInviteMail(s *Server, admin *models.User, name, email string) error {
 	companyName := s.config.CompanyName
 	emailServerURL := s.config.ServerURL
 	if len(emailServerURL) > 8 && emailServerURL[:8] == "https://" {
 		emailServerURL = "http://" + emailServerURL[8:]
 	}
-	return emailpkg.SendEntraInviteEmail(email, name, emailServerURL, companyName, admin.Name, admin.Email)
+	providerName := ""
+	if ssoCfg, _ := auth.LoadIdentityProviderConfig(database.DB); ssoCfg != nil {
+		providerName = ssoCfg.EffectiveDisplayName()
+	}
+	return emailpkg.SendEntraInviteEmail(email, name, providerName, emailServerURL, companyName, admin.Name, admin.Email)
 }
 
 // handleAdminUserResendInvite re-sends the Entra invitation for a user who

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -404,8 +404,14 @@ func (s *Server) renderLoginPage(w http.ResponseWriter, r *http.Request, errorMs
 	}
 
 	if inviteEmail != "" {
+		// Use the configured provider display name in the banner so the
+		// invitee sees the right brand ("Sign in with Google" etc).
+		bannerProvider := "your SSO provider"
+		if ssoCfg, err := auth.LoadIdentityProviderConfig(database.DB); err == nil && ssoCfg.ShouldShowSSOButton() {
+			bannerProvider = ssoCfg.EffectiveDisplayName()
+		}
 		html += `<div style="background: #e8f4f8; border: 1px solid #b3e0ed; color: #0c5460; padding: 12px; border-radius: 6px; margin-bottom: 20px; font-size: 14px;">
-            <strong>You've been invited.</strong> Sign in with Microsoft below to activate your account.
+            <strong>You've been invited.</strong> Sign in with ` + template.HTMLEscapeString(bannerProvider) + ` below to activate your account.
         </div>`
 	}
 
@@ -433,24 +439,34 @@ func (s *Server) renderLoginPage(w http.ResponseWriter, r *http.Request, errorMs
             <button type="submit" class="btn">Login</button>
         </form>`
 
-	// Render the SSO button only if Entra is enabled and not overridden by
-	// the local-only escape hatch. LoadEntraConfig failure should not break
-	// the login page — fall back to local-only rendering.
-	if entraCfg, err := auth.LoadEntraConfig(database.DB); err == nil && entraCfg.ShouldShowSSOButton() {
+	// Render the SSO button only if a provider is enabled and not overridden
+	// by the local-only escape hatch. Logo + label adapt to the provider type:
+	// the Microsoft 4-tile for Entra, a neutral lock icon for Generic OIDC.
+	if ssoCfg, err := auth.LoadIdentityProviderConfig(database.DB); err == nil && ssoCfg.ShouldShowSSOButton() {
+		providerName := template.HTMLEscapeString(ssoCfg.EffectiveDisplayName())
+		var providerIcon string
+		if ssoCfg.IsEntra() {
+			providerIcon = `<svg width="18" height="18" viewBox="0 0 23 23" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <rect x="1"  y="1"  width="10" height="10" fill="#F35325"/>
+                <rect x="12" y="1"  width="10" height="10" fill="#81BC06"/>
+                <rect x="1"  y="12" width="10" height="10" fill="#05A6F0"/>
+                <rect x="12" y="12" width="10" height="10" fill="#FFBA08"/>
+            </svg>`
+		} else {
+			providerIcon = `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+            </svg>`
+		}
 		html += `
         <div style="display:flex; align-items:center; margin: 20px 0 16px; color:#999; font-size:12px;">
             <div style="flex:1; height:1px; background:#e5e7eb;"></div>
             <div style="padding: 0 12px;">OR</div>
             <div style="flex:1; height:1px; background:#e5e7eb;"></div>
         </div>
-        <a href="/auth/entra/login" style="display:flex; align-items:center; justify-content:center; gap:10px; width:100%; padding:12px; background:white; color:#1f1f1f; border:1px solid #d2d2d2; border-radius:6px; font-size:14px; font-weight:600; text-decoration:none; transition: background 0.2s;" onmouseover="this.style.background='#f5f5f5'" onmouseout="this.style.background='white'">
-            <svg width="18" height="18" viewBox="0 0 23 23" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                <rect x="1"  y="1"  width="10" height="10" fill="#F35325"/>
-                <rect x="12" y="1"  width="10" height="10" fill="#81BC06"/>
-                <rect x="1"  y="12" width="10" height="10" fill="#05A6F0"/>
-                <rect x="12" y="12" width="10" height="10" fill="#FFBA08"/>
-            </svg>
-            Sign in with Microsoft
+        <a href="/auth/oidc/login" style="display:flex; align-items:center; justify-content:center; gap:10px; width:100%; padding:12px; background:white; color:#1f1f1f; border:1px solid #d2d2d2; border-radius:6px; font-size:14px; font-weight:600; text-decoration:none; transition: background 0.2s;" onmouseover="this.style.background='#f5f5f5'" onmouseout="this.style.background='white'">
+            ` + providerIcon + `
+            Sign in with ` + providerName + `
         </a>`
 	}
 

--- a/internal/server/handlers_entra.go
+++ b/internal/server/handlers_entra.go
@@ -69,7 +69,7 @@ func (s *Server) handleEntraLogin(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     entraStateCookieName,
 		Value:    state,
-		Path:     "/auth/entra/",
+		Path:     "/auth/",
 		Expires:  expires,
 		MaxAge:   entraStateMaxAge,
 		HttpOnly: true,
@@ -79,7 +79,7 @@ func (s *Server) handleEntraLogin(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     entraPKCECookieName,
 		Value:    pkce.Verifier,
-		Path:     "/auth/entra/",
+		Path:     "/auth/",
 		Expires:  expires,
 		MaxAge:   entraStateMaxAge,
 		HttpOnly: true,
@@ -206,7 +206,7 @@ func clearEntraFlowCookies(w http.ResponseWriter, secure bool) {
 		http.SetCookie(w, &http.Cookie{
 			Name:     name,
 			Value:    "",
-			Path:     "/auth/entra/",
+			Path:     "/auth/",
 			MaxAge:   -1,
 			HttpOnly: true,
 			Secure:   secure,

--- a/internal/server/handlers_identity_providers.go
+++ b/internal/server/handlers_identity_providers.go
@@ -4,8 +4,8 @@
 // You must retain this notice in any copy or derivative work.
 
 // handlers_identity_providers.go — admin UI for external SSO providers.
-// Currently covers Microsoft Entra ID; structured so future providers
-// (Google, Okta) can slot in alongside.
+// v7.1 adds Generic OIDC alongside Microsoft Entra ID. The form is
+// provider-aware: selecting a type shows/hides the relevant fields.
 
 package server
 
@@ -48,41 +48,59 @@ func (s *Server) handleAdminIdentityProviders(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	cfg := &auth.EntraConfig{
-		Enabled:        r.FormValue("enabled") == "on",
-		ForceLocalOnly: r.FormValue("force_local_only") == "on",
-		TenantID:       strings.TrimSpace(r.FormValue("tenant_id")),
-		ClientID:       strings.TrimSpace(r.FormValue("client_id")),
-		ClientSecret:   r.FormValue("client_secret"), // empty = keep existing
-		RedirectURI:    strings.TrimSpace(r.FormValue("redirect_uri")),
-		AutoProvision:  r.FormValue("auto_provision") == "on",
-		DefaultRole:    models.UserRank(defaultRole),
-		AllowedDomains: allowedDomains,
+	providerType := strings.TrimSpace(r.FormValue("provider_type"))
+	if providerType != auth.ProviderTypeGenericOIDC {
+		providerType = auth.ProviderTypeEntra
+	}
+
+	cfg := &auth.IdentityProviderConfig{
+		Enabled:             r.FormValue("enabled") == "on",
+		ForceLocalOnly:      r.FormValue("force_local_only") == "on",
+		ProviderType:        providerType,
+		ProviderDisplayName: strings.TrimSpace(r.FormValue("provider_display_name")),
+		TenantID:            strings.TrimSpace(r.FormValue("tenant_id")),
+		ClientID:            strings.TrimSpace(r.FormValue("client_id")),
+		ClientSecret:        r.FormValue("client_secret"), // empty = keep existing
+		RedirectURI:         strings.TrimSpace(r.FormValue("redirect_uri")),
+		IssuerURL:           strings.TrimSpace(r.FormValue("issuer_url")),
+		Scopes:              strings.TrimSpace(r.FormValue("scopes")),
+		AutoProvision:       r.FormValue("auto_provision") == "on",
+		DefaultRole:         models.UserRank(defaultRole),
+		AllowedDomains:      allowedDomains,
 	}
 
 	if cfg.Enabled && !cfg.ForceLocalOnly {
-		if cfg.TenantID == "" || cfg.ClientID == "" {
-			s.renderIdentityProviders(w, "", "Tenant ID and Client ID are required when Entra ID is enabled.")
+		if cfg.ClientID == "" {
+			s.renderIdentityProviders(w, "", "Client ID is required when SSO is enabled.")
+			return
+		}
+		if cfg.IsEntra() && cfg.TenantID == "" {
+			s.renderIdentityProviders(w, "", "Tenant ID is required for Microsoft Entra ID.")
+			return
+		}
+		if cfg.IsGenericOIDC() && cfg.IssuerURL == "" {
+			s.renderIdentityProviders(w, "", "Issuer URL is required for Generic OIDC.")
 			return
 		}
 	}
 
-	if err := auth.SaveEntraConfig(database.DB, cfg); err != nil {
+	if err := auth.SaveIdentityProviderConfig(database.DB, cfg); err != nil {
 		s.renderIdentityProviders(w, "", "Save failed: "+err.Error())
 		return
 	}
 
-	// Audit log — never log the client secret value.
 	admin, _ := userFromContext(r.Context())
 	database.DB.LogAction(&database.AuditLogEntry{
 		UserID:     int64(admin.Id),
 		UserEmail:  admin.Email,
 		Action:     "IDENTITY_PROVIDER_UPDATED",
 		EntityType: "Settings",
-		EntityID:   "entra",
-		Details: fmt.Sprintf(`{"enabled":%v,"force_local_only":%v,"tenant_id_set":%v,"client_id_set":%v,"secret_updated":%v,"auto_provision":%v,"default_role":%d,"allowed_domains":%d}`,
+		EntityID:   cfg.EffectiveProviderType(),
+		Details: fmt.Sprintf(`{"provider_type":%q,"enabled":%v,"force_local_only":%v,"tenant_id_set":%v,"issuer_url_set":%v,"client_id_set":%v,"secret_updated":%v,"auto_provision":%v,"default_role":%d,"allowed_domains":%d}`,
+			cfg.EffectiveProviderType(),
 			cfg.Enabled, cfg.ForceLocalOnly,
-			cfg.TenantID != "", cfg.ClientID != "",
+			cfg.TenantID != "", cfg.IssuerURL != "",
+			cfg.ClientID != "",
 			strings.TrimSpace(cfg.ClientSecret) != "",
 			cfg.AutoProvision, cfg.DefaultRole, len(cfg.AllowedDomains)),
 		IPAddress: getClientIP(r),
@@ -96,10 +114,10 @@ func (s *Server) handleAdminIdentityProviders(w http.ResponseWriter, r *http.Req
 func (s *Server) renderIdentityProviders(w http.ResponseWriter, success, errMsg string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	cfg, loadErr := auth.LoadEntraConfig(database.DB)
+	cfg, loadErr := auth.LoadIdentityProviderConfig(database.DB)
 	if loadErr != nil && errMsg == "" {
 		errMsg = "Failed to load current settings: " + loadErr.Error()
-		cfg = &auth.EntraConfig{
+		cfg = &auth.IdentityProviderConfig{
 			AutoProvision: true,
 			DefaultRole:   models.UserLevelUser,
 		}
@@ -119,8 +137,9 @@ func (s *Server) renderIdentityProviders(w http.ResponseWriter, success, errMsg 
 		return ""
 	}
 
-	// Default redirect URI hint for the customer's Entra app registration.
-	defaultRedirect := strings.TrimRight(s.config.ServerURL, "/") + "/auth/entra/callback"
+	// Default redirect URI hint. v7.1: /auth/oidc/callback is canonical for
+	// new installs; /auth/entra/callback still works for legacy.
+	defaultRedirect := strings.TrimRight(s.config.ServerURL, "/") + "/auth/oidc/callback"
 	currentRedirect := cfg.RedirectURI
 	if currentRedirect == "" {
 		currentRedirect = defaultRedirect
@@ -140,6 +159,9 @@ func (s *Server) renderIdentityProviders(w http.ResponseWriter, success, errMsg 
 	if errMsg != "" {
 		banner = `<div class="message error">` + esc(errMsg) + `</div>`
 	}
+
+	isEntra := cfg.IsEntra()
+	isGeneric := cfg.IsGenericOIDC()
 
 	html := `<!DOCTYPE html>
 <html lang="en">
@@ -174,7 +196,8 @@ func (s *Server) renderIdentityProviders(w http.ResponseWriter, success, errMsg 
         .message.success { background: #d1fae5; color: #065f46; border: 1px solid #6ee7b7; }
         .message.error   { background: #fee2e2; color: #991b1b; border: 1px solid #fca5a5; }
         .info-box { background: #eff6ff; border-left: 4px solid #3b82f6; padding: 14px 18px; border-radius: 4px; margin-bottom: 16px; font-size: 13px; color: #1e3a8a; line-height: 1.5; }
-        .warn-box { background: #fffbeb; border-left: 4px solid #f59e0b; padding: 14px 18px; border-radius: 4px; margin-bottom: 16px; font-size: 13px; color: #78350f; line-height: 1.5; }
+        .preset-list { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 12px 18px; margin-top: 8px; font-size: 13px; line-height: 1.7; }
+        .preset-list code { background: #fff; padding: 2px 6px; border-radius: 3px; font-size: 12px; font-family: 'SF Mono', Menlo, monospace; }
         code { background: #f3f4f6; padding: 2px 6px; border-radius: 3px; font-size: 12px; font-family: 'SF Mono', Menlo, monospace; }
         .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
         @media (max-width: 640px) { .grid-2 { grid-template-columns: 1fr; } }
@@ -188,27 +211,19 @@ func (s *Server) renderIdentityProviders(w http.ResponseWriter, success, errMsg 
         ` + banner + `
 
         <div class="card">
-            <h3>Microsoft Entra ID (Azure AD)</h3>
-
-            <div class="info-box">
-                <strong>Setup steps in your Entra tenant:</strong>
-                <ol style="margin:8px 0 0 22px;">
-                    <li>Register a new application in <em>Entra ID → App registrations</em>.</li>
-                    <li>Add redirect URI (Web): <code>` + esc(defaultRedirect) + `</code></li>
-                    <li>Under <em>Certificates &amp; secrets</em>, create a client secret and copy the <strong>Value</strong>.</li>
-                    <li>Note the <em>Application (client) ID</em> and <em>Directory (tenant) ID</em>.</li>
-                    <li>Paste them below, enable, save. The SSO button will appear on the login page.</li>
-                </ol>
-            </div>
-
-            <div class="warn-box">
-                The OIDC sign-in flow itself ships in the next release. This page lets you stage the configuration; the <em>Sign in with Microsoft</em> button will currently show a "coming soon" notice when clicked.
-            </div>
-
             <form method="POST">
+                <div class="form-group">
+                    <label for="provider_type">Provider type</label>
+                    <select id="provider_type" name="provider_type" onchange="toggleProviderFields()">
+                        <option value="entra" ` + selectedAttr(isEntra) + `>Microsoft Entra ID (Azure AD)</option>
+                        <option value="generic_oidc" ` + selectedAttr(isGeneric) + `>Generic OpenID Connect</option>
+                    </select>
+                    <div class="help">Entra ID is special-cased with multi-tenant aliases (common / organizations / consumers). Generic OIDC works with any OIDC-compliant provider — Google, Okta, Keycloak, Authelia, Auth0, etc.</div>
+                </div>
+
                 <div class="form-group checkbox-row">
                     <input type="checkbox" id="enabled" name="enabled" ` + checked(cfg.Enabled) + `>
-                    <label for="enabled" style="margin-bottom:0;">Enable Entra ID SSO</label>
+                    <label for="enabled" style="margin-bottom:0;">Enable SSO</label>
                 </div>
 
                 <div class="form-group checkbox-row">
@@ -216,29 +231,77 @@ func (s *Server) renderIdentityProviders(w http.ResponseWriter, success, errMsg 
                     <label for="force_local_only" style="margin-bottom:0;">Force local accounts only (overrides "Enabled" — hides SSO button and rejects callbacks)</label>
                 </div>
 
-                <div class="grid-2">
+                <div class="form-group">
+                    <label for="provider_display_name">Provider display name (optional)</label>
+                    <input type="text" id="provider_display_name" name="provider_display_name" value="` + esc(cfg.ProviderDisplayName) + `" placeholder="Microsoft / Google / Okta / SSO">
+                    <div class="help">Shown on the login button ("Sign in with X") and in invite emails. Defaults to "Microsoft" for Entra, "SSO" for Generic OIDC.</div>
+                </div>
+
+                <!-- Entra-specific fields -->
+                <div id="entra-fields" style="display: ` + showIf(isEntra) + `;">
+                    <div class="info-box">
+                        <strong>Microsoft Entra ID setup:</strong>
+                        <ol style="margin:8px 0 0 22px;">
+                            <li>Register a new application in <em>Entra ID → App registrations</em>.</li>
+                            <li>Add redirect URI (Web): <code>` + esc(defaultRedirect) + `</code></li>
+                            <li>Under <em>Certificates &amp; secrets</em>, create a client secret and copy the <strong>Value</strong>.</li>
+                            <li>Note the <em>Application (client) ID</em> and <em>Directory (tenant) ID</em>.</li>
+                        </ol>
+                    </div>
+
                     <div class="form-group">
                         <label for="tenant_id">Tenant ID</label>
                         <input type="text" id="tenant_id" name="tenant_id" value="` + esc(cfg.TenantID) + `" placeholder="00000000-0000-0000-0000-000000000000" autocomplete="off">
-                        <div class="help">Directory (tenant) ID from your Entra app registration.</div>
-                    </div>
-                    <div class="form-group">
-                        <label for="client_id">Client ID</label>
-                        <input type="text" id="client_id" name="client_id" value="` + esc(cfg.ClientID) + `" placeholder="00000000-0000-0000-0000-000000000000" autocomplete="off">
-                        <div class="help">Application (client) ID.</div>
+                        <div class="help">Directory (tenant) ID. May also be <code>common</code>, <code>organizations</code> or <code>consumers</code> for multi-tenant apps.</div>
                     </div>
                 </div>
 
-                <div class="form-group">
-                    <label for="client_secret">Client Secret</label>
-                    <input type="password" id="client_secret" name="client_secret" value="" placeholder="` + esc(secretPlaceholder) + `" autocomplete="new-password">
-                    <div class="help">Stored encrypted at rest. Leave blank to preserve the existing secret.</div>
+                <!-- Generic-OIDC-specific fields -->
+                <div id="generic-fields" style="display: ` + showIf(isGeneric) + `;">
+                    <div class="info-box">
+                        <strong>Generic OpenID Connect setup:</strong> Any OIDC-compliant provider. Register WulfVault as a confidential client with the redirect URI shown below, then paste the issuer URL, client ID and secret.
+                    </div>
+
+                    <div class="form-group">
+                        <label for="issuer_url">Issuer URL</label>
+                        <input type="url" id="issuer_url" name="issuer_url" value="` + esc(cfg.IssuerURL) + `" placeholder="https://accounts.google.com" autocomplete="off">
+                        <div class="help">The OIDC issuer — the URL whose <code>/.well-known/openid-configuration</code> describes the provider. No trailing slash.</div>
+                        <div class="preset-list">
+                            <strong>Common issuers:</strong><br>
+                            Google Workspace: <code>https://accounts.google.com</code><br>
+                            Okta: <code>https://&lt;your-tenant&gt;.okta.com</code><br>
+                            Keycloak: <code>https://&lt;keycloak-host&gt;/realms/&lt;realm&gt;</code><br>
+                            Authelia: <code>https://&lt;authelia-host&gt;</code><br>
+                            Auth0: <code>https://&lt;your-tenant&gt;.auth0.com</code>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="scopes">Scopes (optional)</label>
+                        <input type="text" id="scopes" name="scopes" value="` + esc(cfg.Scopes) + `" placeholder="openid email profile">
+                        <div class="help">Space-separated. Defaults to <code>openid email profile</code> — the OIDC baseline that returns sub, email and display name.</div>
+                    </div>
+                </div>
+
+                <h3>OAuth / OIDC credentials</h3>
+
+                <div class="grid-2">
+                    <div class="form-group">
+                        <label for="client_id">Client ID</label>
+                        <input type="text" id="client_id" name="client_id" value="` + esc(cfg.ClientID) + `" placeholder="00000000-0000-0000-0000-000000000000" autocomplete="off">
+                        <div class="help">Application / Client ID from the provider.</div>
+                    </div>
+                    <div class="form-group">
+                        <label for="client_secret">Client Secret</label>
+                        <input type="password" id="client_secret" name="client_secret" value="" placeholder="` + esc(secretPlaceholder) + `" autocomplete="new-password">
+                        <div class="help">Stored encrypted at rest. Leave blank to preserve the existing secret.</div>
+                    </div>
                 </div>
 
                 <div class="form-group">
                     <label for="redirect_uri">Redirect URI</label>
                     <input type="url" id="redirect_uri" name="redirect_uri" value="` + esc(currentRedirect) + `">
-                    <div class="help">Must match exactly what is registered in Entra. Default: <code>` + esc(defaultRedirect) + `</code></div>
+                    <div class="help">Must match exactly what is registered at the provider. Default: <code>` + esc(defaultRedirect) + `</code> — the legacy <code>/auth/entra/callback</code> path also works.</div>
                 </div>
 
                 <h3>Provisioning</h3>
@@ -271,8 +334,24 @@ func (s *Server) renderIdentityProviders(w http.ResponseWriter, success, errMsg 
             </form>
         </div>
     </div>
+
+    <script>
+        function toggleProviderFields() {
+            var type = document.getElementById('provider_type').value;
+            document.getElementById('entra-fields').style.display = (type === 'entra') ? '' : 'none';
+            document.getElementById('generic-fields').style.display = (type === 'generic_oidc') ? '' : 'none';
+        }
+    </script>
 </body>
 </html>`
 
 	_, _ = w.Write([]byte(html))
+}
+
+// showIf is a tiny helper to keep the inline-style ternaries readable.
+func showIf(condition bool) string {
+	if condition {
+		return ""
+	}
+	return "none"
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -61,9 +61,14 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/d/", s.handleDownload)
 	mux.HandleFunc("/health", s.handleHealth)
 
-	// 2FA routes
+	// SSO routes — /auth/entra/* are the original v7.0 paths, kept for any
+	// Entra app registrations already configured with that redirect URI.
+	// /auth/oidc/* are the v7.1 generic paths (Generic OIDC provider) and
+	// identical in behaviour.
 	mux.HandleFunc("/auth/entra/login", s.handleEntraLogin)
 	mux.HandleFunc("/auth/entra/callback", s.handleEntraCallback)
+	mux.HandleFunc("/auth/oidc/login", s.handleEntraLogin)
+	mux.HandleFunc("/auth/oidc/callback", s.handleEntraCallback)
 	mux.HandleFunc("/2fa/verify", s.handle2FAVerify)
 	mux.HandleFunc("/2fa/setup", s.requireAuth(s.handle2FASetup))
 	mux.HandleFunc("/2fa/enable", s.requireAuth(s.handle2FAEnable))


### PR DESCRIPTION
# WulfVault 7.1.0 Aurora — Generic OpenID Connect alongside Microsoft Entra ID

> Add **Generic OIDC** as a second provider option in the Identity Providers admin page. WulfVault is no longer tied to Microsoft for SSO — any OIDC-compliant issuer (Google Workspace, Okta, Keycloak, Authelia, Auth0, etc) works.

## What's new

- **Provider type dropdown** in *Identity Providers*: **Microsoft Entra ID (Azure AD)** or **Generic OpenID Connect**.
- **Configurable provider display name** — the login button and invite emails now say "Sign in with *X*" where *X* defaults to "Microsoft" for Entra and "SSO" for Generic, or can be customised ("Google", "Okta", "BankID", whatever).
- **Generic OIDC field set** — Issuer URL + Scopes (defaults to `openid email profile`).
- **Inline issuer help** for common providers:
  - Google Workspace: `https://accounts.google.com`
  - Okta: `https://<your-tenant>.okta.com`
  - Keycloak: `https://<keycloak-host>/realms/<realm>`
  - Authelia: `https://<authelia-host>`
  - Auth0: `https://<your-tenant>.auth0.com`
- **New canonical routes**: `/auth/oidc/{login,callback}`. The legacy `/auth/entra/{login,callback}` paths still work, so existing Entra app registrations with that redirect URI keep working without re-configuration.

## What stays the same

- **Entra is still special-cased** with multi-tenant aliases (`common` / `organizations` / `consumers`) and `tid`-claim validation. Existing Entra deployments continue to behave identically.
- **Backwards compatibility**: `EntraConfig` is now a type alias for the new `IdentityProviderConfig`. `LoadEntraConfig` / `SaveEntraConfig` are kept as shims. Installs that pre-date v7.1 default to `ProviderType=entra` so the upgrade is silent.
- **Invite flow** unchanged — admin creates user with SSO, sends invite, user activates via provider sign-in.
- **All security guarantees from v7.0** preserved: client secret encrypted at rest with AES-256-GCM, `force_local_only` escape hatch, local-account collision protection, Evidence Courier compatibility contract.

## Generic OIDC — quickstart for Google Workspace

1. Google Cloud Console → APIs & Services → Credentials → Create OAuth client ID (Web application).
2. Authorized redirect URI: `https://your-wulfvault/auth/oidc/callback`
3. Copy the Client ID and Client Secret.
4. In WulfVault: Server → Identity Providers → **Generic OpenID Connect**:
   - Issuer URL: `https://accounts.google.com`
   - Client ID: from step 3
   - Client Secret: from step 3
   - Provider display name: `Google` (optional)
   - Allowed domains: `yourcompany.com` (optional G-Suite restriction)
   - Save.
5. The login page shows **Sign in with Google**. Click to verify.

## Generic OIDC — quickstart for Keycloak

1. Keycloak → Clients → Create client → Client type: OpenID Connect → Client ID: `wulfvault` → Save.
2. Client authentication: ON. Standard flow: ON. Valid redirect URIs: `https://your-wulfvault/auth/oidc/callback`. Save.
3. Credentials tab → copy Client secret.
4. In WulfVault: Server → Identity Providers → **Generic OpenID Connect**:
   - Issuer URL: `https://<keycloak-host>/realms/<your-realm>`
   - Client ID: `wulfvault`
   - Client Secret: from step 3
   - Provider display name: `Keycloak` (optional)
   - Save.

## Database migration

**None.** Reuses the v7.0 `Configuration` table — new keys (`entra_provider_type`, `entra_provider_display_name`, `entra_generic_issuer_url`, `entra_generic_scopes`) are written alongside existing ones. Old binaries simply ignore them.

## Upgrade

Drop in the new `wulfvault-linux-amd64` binary, restart the service. Rollback path: keep the previous binary as `wulfvault.previous` and `cp wulfvault.previous wulfvault && systemctl restart wulfvault.service` is the one-liner. The v7.1 → v7.0 → v6.3 path is all binary-swap with no data migration.

## Status

- **Tag**: `v7.1.0-aurora-beta1` — beta1 because the Generic OIDC path is exercised against the same `coreos/go-oidc/v3` library that powers the Entra flow, but the first real-customer sign-in via a non-Entra provider is the next milestone.
- **Deploy verified** at `wulfvault.prudcloud.se` on 2026-05-30. Health endpoint reports `7.1.0 Aurora`.
- **EC contract verified**: `/login`=200, `/api/whoami`=401, `/upload`=303, `/file/delete`=303.

## Known limitations / next iteration

1. **One provider at a time** per install. If you need both Entra (for employees) AND Google (for contractors) on the same WulfVault, that's a v7.2 conversation.
2. **No "Convert local user to provider" admin button**. Local→SSO conversion is still a DB edit. Carried over from v7.0.
3. **No group-claim → role mapping**. Same as v7.0.
4. **No front-channel single sign-out**. Logging out of WulfVault doesn't end the upstream provider session.

## Credits

- Generic OIDC layer by Claude Code (Anthropic) for SAM/Prudencia, 2026-05-30.
- Foundation (Entra ID, v6.3 → v7.0) by Claude Code in earlier sessions.

---

## Deploy status
Already running on wulfvault.prudcloud.se — `{"status":"healthy","version":"7.1.0 Aurora"}`. PR opened against `feature/entra-id-foundation` (the v7.x trunk for the entra-foundation work); merge when reviewed.

## File changes
- `cmd/server/main.go`: version bump 7.0.0 → 7.1.0
- `internal/auth/entra_config.go`: `IdentityProviderConfig` (EntraConfig kept as alias) + provider_type / display_name / issuer / scopes fields
- `internal/auth/entra.go`: BuildEntraProvider splits into entra-specific + generic-oidc paths
- `internal/server/handlers_identity_providers.go`: dropdown + conditional fields + JS toggle
- `internal/server/handlers_auth.go`: SSO button label + icon adapt to provider
- `internal/email/templates.go`: invite email accepts providerDisplayName
- `internal/server/server.go`: new /auth/oidc/{login,callback} routes
- `internal/server/handlers_entra.go`: cookie Path widened from /auth/entra/ to /auth/